### PR TITLE
Field type refactored

### DIFF
--- a/bkash/models/bkash_webhook_message.go
+++ b/bkash/models/bkash_webhook_message.go
@@ -1,18 +1,18 @@
 package models
 
 type WebhookData struct {
-	Type             string `json:"Type"`
-	MessageId        string `json:"MessageId"`
-	Token            string `json:"Token"`
-	TopicArn         string `json:"TopicArn"`
-	Message          string `json:"Message"`
-	Timestamp        string `json:"Timestamp"`
-	SignatureVersion string `json:"SignatureVersion"`
-	Signature        string `json:"Signature"`
-	SigningCertURL   string `json:"SigningCertURL"`
-	UnsubscribeURL   string `json:"UnsubscribeURL"`
-	SubscribeURL     string `json:"SubscribeURL"`
-	Subject          string `json:"Subject"`
+	Type             string      `json:"Type"`
+	MessageId        string      `json:"MessageId"`
+	Token            string      `json:"Token"`
+	TopicArn         string      `json:"TopicArn"`
+	Message          interface{} `json:"Message"`
+	Timestamp        string      `json:"Timestamp"`
+	SignatureVersion string      `json:"SignatureVersion"`
+	Signature        string      `json:"Signature"`
+	SigningCertURL   string      `json:"SigningCertURL"`
+	UnsubscribeURL   string      `json:"UnsubscribeURL"`
+	SubscribeURL     string      `json:"SubscribeURL"`
+	Subject          string      `json:"Subject"`
 }
 
 type Message struct {


### PR DESCRIPTION
Message field of WebhookData model changed to `interface{} ` type to `String` type, which solves the json Unmarshal error as BKash IPN Message are different for `SubscriptionConfirmation` and `Notification` 